### PR TITLE
Fix keyWithSuffix generation

### DIFF
--- a/src/test/java/ru/mail/polis/lsm/Utils.java
+++ b/src/test/java/ru/mail/polis/lsm/Utils.java
@@ -60,7 +60,11 @@ class Utils {
     }
 
     static ByteBuffer keyWithSuffix(int key, byte[] suffix) {
-        byte[] keyBytes = (KEY_PREFIX + "_" + key).getBytes(StandardCharsets.UTF_8);
+        String binary = Long.toBinaryString(key);
+        int leadingN = 64 - binary.length();
+        String builder = "0".repeat(leadingN) + binary;
+
+        byte[] keyBytes = (KEY_PREFIX + "_" + builder).getBytes(StandardCharsets.UTF_8);
         byte[] result = new byte[keyBytes.length + suffix.length];
         System.arraycopy(keyBytes, 0, result, 0, keyBytes.length);
         System.arraycopy(suffix, 0, result, keyBytes.length, suffix.length);


### PR DESCRIPTION
Ключи в дао - строки, следовательно упорядочены согласно алфавитному порядку.
Ключи при подготовке дао генерируются таким образом, что в начале стоит число, которое увеличивается с каждым следующим ключом, а затем одна и та же строка. Это приводит к тому, что как только количество итераций переходит за 10, новые ключи перестают вставать в "конец" дао, а вставляются где-то в середине согласно алфавитному порядку. 
Тест же проверяет чтобы ключи шли ровно в том порядке, в котором генерировались. 
Предлагаемое решение - использовать последовательные двоичные числа с ведущими нулями в качестве индекса.